### PR TITLE
Couple of small fixes for windows build

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "esp"

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::{Condvar, Mutex};
 use std::{cell::RefCell, env, sync::atomic::*, sync::Arc, thread, time::*};
+use std::result::Result::Ok;
 
 use anyhow::*;
 use log::*;


### PR DESCRIPTION
Hi,
I've added a couple of small fixes

The one involving use std::result::Result::Ok; might be related to the latest toolchain I'm not sure
but seems to be a requirement for the build to work

The rust-toolchain.toml file is just a convenience to default the toolchain to use as "esp"
