### PR TITLE
Fixed missing anyhow macro used when compiling for the esp32s2.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -772,7 +772,7 @@ fn httpd_ulp_endpoints(
                 .filter(|p| p.0 == "cycles")
                 .map(|p| str::parse::<u32>(&p.1).map_err(Error::msg))
                 .next()
-                .ok_or(anyhow!("No parameter cycles"))??;
+                .ok_or(anyhow::anyhow!("No parameter cycles"))??;
 
             let mut wait = mutex.0.lock().unwrap();
 


### PR DESCRIPTION
Hi,
when compiling for the esp32s2 the anyhow macro is not in scope.