### PR TITLE
Support for generic SDD1306 display accessed via SPI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ ttgo = []
 # Enable this feature in case you have an ESP32S3-USB-OTG board and would like to see a LED screen demo
 heltec = []
 
-# Enable this feature in case you have an SSD1306 Display connected via SPI and would like to see the LED screen demo
-heltec_spi = []
+# Enable this feature in case you have a generic SSD1306 Display connected via SPI to pins 3, 4, 5, 16, 18, 23 (SPI3) of your board
+ssd1306g_spi = []
 
 # Enable this feature in case you have a generic SSD1306 screen connected to pins 14, 22 and 21 of your board
 ssd1306g = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ ttgo = []
 # Enable this feature in case you have an ESP32S3-USB-OTG board and would like to see a LED screen demo
 heltec = []
 
+# Enable this feature in case you have an SSD1306 Display connected via SPI and would like to see the LED screen demo
+heltec_spi = []
+
 # Enable this feature in case you have a generic SSD1306 screen connected to pins 14, 22 and 21 of your board
 ssd1306g = []
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,8 +157,8 @@ fn main() -> Result<()> {
     #[cfg(feature = "heltec")]
     heltec_hello_world(pins.gpio16, peripherals.i2c0, pins.gpio4, pins.gpio15)?;
 
-    #[cfg(feature = "heltec_spi")]
-    heltec_hello_world_spi(pins.gpio4, pins.gpio16, peripherals.spi3, pins.gpio18, pins.gpio23, pins.gpio5)?;
+    #[cfg(feature = "ssd1306g_spi")]
+    ssd1306g_hello_world_spi(pins.gpio4, pins.gpio16, peripherals.spi3, pins.gpio18, pins.gpio23, pins.gpio5)?;
 
     #[cfg(feature = "ssd1306g")]
     let mut led_power =
@@ -723,8 +723,8 @@ fn heltec_hello_world(
     })
 }
 
-#[cfg(feature = "heltec_spi")]
-fn heltec_hello_world_spi(
+#[cfg(feature = "ssd1306g_spi")]
+fn ssd1306g_hello_world_spi(
     dc: gpio::Gpio4<gpio::Unknown>,
     rst: gpio::Gpio16<gpio::Unknown>,
     spi: spi::SPI3,
@@ -732,7 +732,7 @@ fn heltec_hello_world_spi(
     sdo: gpio::Gpio23<gpio::Unknown>,
     cs: gpio::Gpio5<gpio::Unknown>, 
 ) -> Result<()> {
-    info!("About to initialize the Heltec SSD1306 SPI LED driver");
+    info!("About to initialize the SSD1306 SPI LED driver");
 
     let config = <spi::config::Config as Default>::default()
         .baudrate(10.MHz().into())

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,14 @@ fn main() -> Result<()> {
     heltec_hello_world(pins.gpio16, peripherals.i2c0, pins.gpio4, pins.gpio15)?;
 
     #[cfg(feature = "ssd1306g_spi")]
-    ssd1306g_hello_world_spi(pins.gpio4, pins.gpio16, peripherals.spi3, pins.gpio18, pins.gpio23, pins.gpio5)?;
+    ssd1306g_hello_world_spi(
+        pins.gpio4,
+        pins.gpio16,
+        peripherals.spi3,
+        pins.gpio18,
+        pins.gpio23,
+        pins.gpio5,
+    )?;
 
     #[cfg(feature = "ssd1306g")]
     let mut led_power =
@@ -730,7 +737,7 @@ fn ssd1306g_hello_world_spi(
     spi: spi::SPI3,
     sclk: gpio::Gpio18<gpio::Unknown>,
     sdo: gpio::Gpio23<gpio::Unknown>,
-    cs: gpio::Gpio5<gpio::Unknown>, 
+    cs: gpio::Gpio5<gpio::Unknown>,
 ) -> Result<()> {
     info!("About to initialize the SSD1306 SPI LED driver");
 


### PR DESCRIPTION
I have extended your demo with a generic SSD1306 diplay that is driven via SPI. If you feel this is useful I would be happy to contribute this code...

The code originates from your heltec functions and is switched to access via SPI3.