### PR TITLE
Fix esp32s3_usb_otg and anyhow calls

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -797,10 +797,10 @@ fn ttgo_hello_world(
 
     display
         .init(&mut delay::Ets)
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
     display
         .set_orientation(st7789::Orientation::Portrait)
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
     // The TTGO board's screen does not start at offset 0x0, and the physical size is 135x240, instead of 240x320
     let top_left = Point::new(52, 40);
@@ -862,10 +862,10 @@ fn kaluga_hello_world(
 
         display
             .init(&mut delay::Ets)
-            .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+            .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
         display
             .set_orientation(st7789::Orientation::Landscape)
-            .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+            .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
         led_draw(&mut display)
     }
@@ -908,13 +908,13 @@ fn heltec_hello_world(
 
     display
         .init()
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
     led_draw(&mut display)?;
 
     display
         .flush()
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
     Ok(())
 }
@@ -966,13 +966,13 @@ fn ssd1306g_hello_world_spi(
 
     display
         .init()
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
     led_draw(&mut display)?;
 
     display
         .flush()
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
     Ok(())
 }
@@ -1014,13 +1014,13 @@ fn ssd1306g_hello_world(
 
     display
         .init()
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
     led_draw(&mut display)?;
 
     display
         .flush()
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
     Ok(power)
 }
@@ -1062,12 +1062,12 @@ fn esp32s3_usb_otg_hello_world(
 
     display
         .init(&mut delay::Ets)
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
     display
         .set_orientation(st7789::Orientation::Landscape)
-        .map_err(|e| anyhow::message("Display error: {:?}", e))?;
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
-    led_draw(&mut display)
+    led_draw(&mut display).map_err(|e| anyhow::anyhow!("Led draw error: {:?}", e))
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
- [x] Replace all instance of `anyhow::message` with `anyhow::anyhow!`
- [x] Fix the esp32s3_usb_otg build

```bash
$ cargo build --features esp32s3_usb_otg
...
error[E0425]: cannot find function `message` in crate `anyhow`
    --> src\main.rs:1065:30
     |
1065 |         .map_err(|e| anyhow::message("Display error: {:?}", e))?;
     |                              ^^^^^^^ not found in `anyhow`

error[E0425]: cannot find function `message` in crate `anyhow`
error[E0277]: the trait bound `st7789::Error<EspError>: std::error::Error` is not satisfied
    --> src\main.rs:1070:30
     |
1070 |     Ok(led_draw(&mut display)?)
     |                              ^ the trait `std::error::Error` is not implemented for `st7789::Error<EspError>`
     |
     = note: required because of the requirements on the impl of `From<st7789::Error<EspError>>` for `anyhow::Error`
     = note: required because of the requirements on the impl of `FromResidual<std::result::Result<Infallible, st7789::Error<EspError>>>` for `std::result::Result<(), anyhow::Error>`
```