### PR TITLE
Fix ttgo and kaluga features

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -768,9 +768,7 @@ fn ttgo_hello_world(
 ) -> Result<()> {
     info!("About to initialize the TTGO ST7789 LED driver");
 
-    let config = <spi::config::Config as Default>::default()
-        .write_only(true)
-        .baudrate(80.MHz().into());
+    let config = <spi::config::Config as Default>::default().baudrate(26.MHz().into());
 
     let mut backlight = backlight.into_output()?;
     backlight.set_high()?;
@@ -857,7 +855,8 @@ fn kaluga_hello_world(
             &mut delay::Ets,
             KalugaOrientation::Landscape,
             ili9341::DisplaySize240x320,
-        )?;
+        )
+        .map_err(|e| anyhow::anyhow!("Display error: {:?}", e))?;
 
         led_draw(&mut display).map_err(|e| anyhow::anyhow!("Display error: {:?}", e))
     } else {


### PR DESCRIPTION
- Remove `write_only` on `spi::config::Config` for `ttgo` as it's not released yet
- Fix #92 : Convert error to `anyhow::Error` for `kaluga` feature