### PR TITLE
fix https_client bug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -745,11 +745,11 @@ mod experimental {
 
         let mut body = [0_u8; 3048];
 
-        let (body, _) = io::read_max(response.reader(), &mut body)?;
+        io::read_max(response.reader(), &mut body)?;
 
         info!(
             "Body (truncated to 3K):\n{:?}",
-            String::from_utf8_lossy(body).into_owned()
+            String::from_utf8_lossy(&body).into_owned()
         );
 
         Ok(())


### PR DESCRIPTION
I fixed a bug described in [this issue](https://github.com/ivmarkov/rust-esp32-std-demo/issues/103) in which the `body` variable in the  `test_https_client()` is set to an empty buffer which prevents the user of the demo from seeing the actual HTTP response.