### PR TITLE
Fix recent napt changes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1415,7 +1415,7 @@ fn ping(ip_settings: &ipv4::ClientSettings) -> Result<()> {
 }
 
 #[cfg(not(feature = "qemu"))]
-#[cfg(esp_idf_lwip_ipv4_)]
+#[cfg(esp_idf_lwip_ipv4_napt)]
 fn enable_napt(wifi: &mut EspWifi) -> Result<()> {
     wifi.with_router_netif_mut(|netif| netif.unwrap().enable_napt(true));
 


### PR DESCRIPTION
I tried to run the example just now and happened to have an error here ("enable_napt not found in this scope").

I assume this was a typo and I was unlucky (change is now 10h ago :D)


On another note: I also had errors because of the issue https://github.com/esp-rs/esp-idf-svc/pull/98 solved, so I had to switch to the git master for that dep. But I guess it's better to wait until a new version is released there.