### PR TITLE
Define partition config in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ anyhow = "1"
 
 # Future; might be possible once https://github.com/rust-lang/cargo/issues/9096 hits Cargo nightly:
 #rust-esp32-ulp-blink = { git = "https://github.com/ivmarkov/rust-esp32-ulp-blink", artifact = "bin" }
+
+[package.metadata.espflash]
+partition_table = "partitions.csv"


### PR DESCRIPTION
Fixes #116 by setting `partition.csv` path in `Cargo.toml` as described [here](https://github.com/esp-rs/espflash/blob/master/cargo-espflash/README.md#package-metadata)