### PR TITLE
Use the partitions.csv file in the git root

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -22,3 +22,8 @@ CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=y
 
 # Future: proper back-trace for esp32c3
 #CONFIG_ESP_SYSTEM_USE_EH_FRAME=y
+
+#Use the partitions.csv file in the git root
+CONFIG_PARTITION_TABLE_SINGLE_APP=
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="../../../../../../partitions.csv"


### PR DESCRIPTION
Fixes #116

Also bails with build failures if the image would not fit into the partitions defined by the csv file.