### PR TITLE
Update ili9341 deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ embedded-graphics = "0.7"
 display-interface = "0.4"
 display-interface-spi = "0.4"
 st7789 = "0.6"
-ili9341 = "0.5"
+ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs", rev = "32ca780" }
 ssd1306 = "0.7"
 epd-waveshare = "0.5.0"
 smol = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ embedded-graphics = "0.7"
 display-interface = "0.4"
 display-interface-spi = "0.4"
 st7789 = "0.6"
-ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
+ili9341 = "0.5"
 ssd1306 = "0.7"
 epd-waveshare = "0.5.0"
 smol = "1.2"


### PR DESCRIPTION
Since yesterday ili9341 point to the embedded-hal 1.0.0-alpha9 in his last version.
Build failed.
https://github.com/yuri91/ili9341-rs/commit/aa0003d0a4b7cf073217a42b4e919d37cfcc1b09

